### PR TITLE
Add assistant.chat.rootAgentName 

### DIFF
--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -106,7 +106,7 @@ config:
     # Enable multiple datasource
     data_source.enabled: true
     assistant.chat.enabled: true
-    assistant.chat.rootAgentId: "fake_agent"
+    assistant.chat.rootAgentName: "Root agent"
     # workspace.enabled: true
     # Enable ml_commons_dashboards
     # ml_commons_dashboards.enabled: true


### PR DESCRIPTION
Replace assistant.chat.rootAgentId with assistant.chat.rootAgentName, it will be used to search root agent id for chatbot's rootagent